### PR TITLE
Hide annoying warning "no department given for StringLiterals."

### DIFF
--- a/config/private/standard.yml
+++ b/config/private/standard.yml
@@ -7,7 +7,7 @@ AllCops:
 Metrics/LineLength:
   Max: 120
 
-StringLiterals:
+Style/StringLiterals:
   EnforcedStyle: single_quotes
 
 Style/FrozenStringLiteralComment:


### PR DESCRIPTION
The title names it.


P.S. I guess its nice idea to have the cops sorted alphabetically and enabled by default, but wasn't sure to do these things.