### PR TITLE
update: rubocop-rspec 2.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 Gemfile.lock
 Gemfile.local
 *.gem
+.idea

--- a/jetrockets-standard.gemspec
+++ b/jetrockets-standard.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop-rails'
-  spec.add_dependency 'rubocop-rspec'
-  spec.add_dependency 'standard', '~> 1.1.1'
+  spec.add_dependency 'rubocop-rspec', '~> 2.7.0'
+  spec.add_dependency 'standard', '~> 1.6.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'rspec', '~> 3.10'
 end


### PR DESCRIPTION
Update `rubocop-rspec` to [`2.7.0` version](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.7.0)

